### PR TITLE
Python 3.5 support

### DIFF
--- a/uotp/cli.py
+++ b/uotp/cli.py
@@ -25,10 +25,10 @@ def cli(ctx, conf):
     path = Path(conf).expanduser()
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
-        fp = click.open_file(path, 'r+', encoding='utf-8')
+        fp = click.open_file(str(path), 'r+', encoding='utf-8')
         config = yaml.load(fp)
     else:
-        fp = click.open_file(path, 'w', encoding='utf-8')
+        fp = click.open_file(str(path), 'w', encoding='utf-8')
         config = {
             'account': None,
             'timediff': 0,


### PR DESCRIPTION
open() accepts Path-like objects only in Python 3.6+, so we have to convert
it to a string in order to support Python 3.5.

https://docs.python.org/3.5/library/functions.html#open
https://docs.python.org/3.6/library/functions.html#open